### PR TITLE
Go back to using explicit queue

### DIFF
--- a/src/main/scala/org/geneontology/whelk/Model.scala
+++ b/src/main/scala/org/geneontology/whelk/Model.scala
@@ -1,5 +1,7 @@
 package org.geneontology.whelk
 
+sealed trait QueueExpression
+
 sealed trait Entity
 
 trait HasSignature {
@@ -20,7 +22,7 @@ object Role {
 
 }
 
-sealed trait Concept extends HasSignature {
+sealed trait Concept extends QueueExpression with HasSignature {
 
   def conceptSignature: Set[Concept]
 
@@ -126,7 +128,7 @@ final case class Nominal(individual: Individual) extends Concept {
 
 }
 
-final case class ConceptInclusion(subclass: Concept, superclass: Concept) extends Axiom {
+final case class ConceptInclusion(subclass: Concept, superclass: Concept) extends Axiom with QueueExpression {
 
   def signature: Set[Entity] = subclass.signature ++ superclass.signature
 
@@ -157,6 +159,10 @@ final case class RoleAssertion(role: Role, subject: Individual, target: Individu
   override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
 
 }
+
+final case class Link(subject: Concept, role: Role, target: Concept) extends QueueExpression
+
+final case class `Sub+`(ci: ConceptInclusion) extends QueueExpression
 
 sealed trait IndividualArgument extends HasSignature
 

--- a/src/main/scala/org/geneontology/whelk/Reasoner.scala
+++ b/src/main/scala/org/geneontology/whelk/Reasoner.scala
@@ -7,7 +7,7 @@ final case class ReasonerState(
                                 hier: Map[Role, Set[Role]], // initial
                                 hierComps: Map[Role, Map[Role, List[Role]]], // initial
                                 assertions: List[ConceptInclusion],
-                                todo: List[ConceptInclusion],
+                                todo: List[QueueExpression],
                                 topOccursNegatively: Boolean,
                                 inits: Set[Concept], // closure
                                 assertedConceptInclusionsBySubclass: Map[Concept, List[ConceptInclusion]],
@@ -132,50 +132,66 @@ object Reasoner {
       val item :: todoAssertions = reasoner.assertions
       computeClosure(processAssertedConceptInclusion(item, reasoner.copy(assertions = todoAssertions)))
     } else if (reasoner.todo.nonEmpty) {
-      val ConceptInclusion(subclass, superclass) :: todo = reasoner.todo
-      computeClosure(processConceptInclusion(subclass, superclass, reasoner.copy(todo = todo)))
+      val item :: todo = reasoner.todo
+      computeClosure(process(item, reasoner.copy(todo = todo)))
     } else reasoner
   }
 
+
   private[this] def processAssertedConceptInclusion(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
-    val ConceptInclusion(subclass, superclass) = ci
     val updated = reasoner.assertedConceptInclusionsBySubclass.updated(ci.subclass, ci :: reasoner.assertedConceptInclusionsBySubclass.getOrElse(ci.subclass, Nil))
-    `R⊑left`(subclass, superclass, `R+∃a`(subclass, superclass, `R+⨅a`(subclass, superclass, `R⊤left`(subclass, superclass, reasoner.copy(assertedConceptInclusionsBySubclass = updated)))))
+    `R⊑left`(ci, `R+∃a`(ci, `R+⨅a`(ci, `R⊤left`(ci, reasoner.copy(assertedConceptInclusionsBySubclass = updated)))))
   }
 
-  private[this] def processConcept(concept: Concept, reasoner: ReasonerState): ReasonerState =
+  private[this] def process(expression: QueueExpression, reasoner: ReasonerState): ReasonerState = {
+    expression match {
+      case link: Link                   => processLink(link, reasoner)
+      case ci: ConceptInclusion         => processConceptInclusion(ci, reasoner)
+      case `Sub+`(ci: ConceptInclusion) => processSubPlus(ci, reasoner)
+      case concept: Concept             => processConcept(concept, reasoner)
+    }
+  }
+
+  private[this] def processConcept(concept: Concept, reasoner: ReasonerState): ReasonerState = {
     if (reasoner.inits(concept)) reasoner else
       `R⊤right`(concept, R0(concept, reasoner.copy(inits = reasoner.inits + concept)))
+  }
 
-  private[whelk] def processConceptInclusion(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
+
+  private[this] def processConceptInclusion(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    val ConceptInclusion(subclass, superclass) = ci
     val subs = reasoner.closureSubsBySuperclass.getOrElse(superclass, Set.empty)
     if (subs(subclass)) reasoner else {
       val closureSubsBySuperclass = reasoner.closureSubsBySuperclass.updated(superclass, subs + subclass)
       val supers = reasoner.closureSubsBySubclass.getOrElse(subclass, Set.empty)
       val closureSubsBySubclass = reasoner.closureSubsBySubclass.updated(subclass, supers + superclass)
-      val updatedReasoner = `R⊑right`(subclass, superclass, `R+∃b-right`(subclass, superclass, `R-∃`(subclass, superclass, `R+⨅b-right`(subclass, superclass, `R+⨅right`(subclass, superclass, `R-⨅`(subclass, superclass, `R⊥left`(subclass, superclass, reasoner.copy(closureSubsBySuperclass = closureSubsBySuperclass, closureSubsBySubclass = closureSubsBySubclass))))))))
-      subclass match {
-        case Nominal(ind) => reasoner.ruleEngine.processConceptAssertion(ConceptAssertion(superclass, ind), updatedReasoner)
-        case _            => updatedReasoner
+      val updatedReasoner = `R⊑right`(ci, `R+∃b-right`(ci, `R-∃`(ci, `R+⨅b-right`(ci, `R+⨅right`(ci, `R-⨅`(ci, `R⊥left`(ci, reasoner.copy(closureSubsBySuperclass = closureSubsBySuperclass, closureSubsBySubclass = closureSubsBySubclass))))))))
+      ci match {
+        case ConceptInclusion(Nominal(ind), concept) => reasoner.ruleEngine.processConceptAssertion(ConceptAssertion(concept, ind), updatedReasoner)
+        case _                                       => updatedReasoner
       }
     }
   }
 
-  private[this] def processSubPlus(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
+
+  private[this] def processSubPlus(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    val ConceptInclusion(subclass, superclass) = ci
     val subs = reasoner.closureSubsBySuperclass.getOrElse(superclass, Set.empty)
     if (subs(subclass)) reasoner else {
       val closureSubsBySuperclass = reasoner.closureSubsBySuperclass.updated(superclass, subs + subclass)
       val supers = reasoner.closureSubsBySubclass.getOrElse(subclass, Set.empty)
       val closureSubsBySubclass = reasoner.closureSubsBySubclass.updated(subclass, supers + superclass)
-      val updatedReasoner = `R⊑right`(subclass, superclass, `R+∃b-right`(subclass, superclass, `R+⨅b-right`(subclass, superclass, `R+⨅right`(subclass, superclass, `R⊥left`(subclass, superclass, reasoner.copy(closureSubsBySuperclass = closureSubsBySuperclass, closureSubsBySubclass = closureSubsBySubclass))))))
-      subclass match {
-        case Nominal(ind) => updatedReasoner.ruleEngine.processConceptAssertion(ConceptAssertion(superclass, ind), updatedReasoner)
-        case _            => updatedReasoner
+      val updatedReasoner = `R⊑right`(ci, `R+∃b-right`(ci, `R+⨅b-right`(ci, `R+⨅right`(ci, `R⊥left`(ci, reasoner.copy(closureSubsBySuperclass = closureSubsBySuperclass, closureSubsBySubclass = closureSubsBySubclass))))))
+      ci match {
+        case ConceptInclusion(Nominal(ind), concept) => updatedReasoner.ruleEngine.processConceptAssertion(ConceptAssertion(concept, ind), updatedReasoner)
+        case _                                       => updatedReasoner
       }
     }
   }
 
-  private[whelk] def processLink(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState = {
+
+  private[this] def processLink(link: Link, reasoner: ReasonerState): ReasonerState = {
+    val Link(subject, role, target) = link
     val rolesToTargets = reasoner.linksBySubject.getOrElse(subject, Map.empty)
     val targetsSet = rolesToTargets.getOrElse(role, Set.empty[Concept])
     if (targetsSet(target)) reasoner else {
@@ -187,60 +203,65 @@ object Reasoner {
       val updatedSubjects = subject :: subjects
       val updatedRolesToSubjects = rolesToSubjects.updated(role, updatedSubjects)
       val linksByTarget = reasoner.linksByTarget.updated(target, updatedRolesToSubjects)
-      val updatedReasoner = `R⤳`(subject, role, target, `R∘left`(subject, role, target, `R∘right`(subject, role, target, `R+∃right`(subject, role, target, `R⊥right`(subject, role, target, reasoner.copy(linksBySubject = linksBySubject, linksByTarget = linksByTarget))))))
-      subject match {
-        case Nominal(subjectInd) => target match {
-          case Nominal(targetInd) => updatedReasoner.ruleEngine.processRoleAssertion(RoleAssertion(role, subjectInd, targetInd), updatedReasoner)
-          case _                  => updatedReasoner
-        }
-        case _                   => updatedReasoner
+      val updatedReasoner = `R⤳`(link, `R∘left`(link, `R∘right`(link, `R+∃right`(link, `R⊥right`(link, reasoner.copy(linksBySubject = linksBySubject, linksByTarget = linksByTarget))))))
+      link match {
+        case Link(Nominal(subjectInd), aRole, Nominal(targetInd)) => updatedReasoner.ruleEngine.processRoleAssertion(RoleAssertion(aRole, subjectInd, targetInd), updatedReasoner)
+        case _                                                    => updatedReasoner
       }
     }
   }
+
 
   private[this] def R0(concept: Concept, reasoner: ReasonerState): ReasonerState =
-    processConceptInclusion(concept, concept, reasoner)
+    reasoner.copy(todo = ConceptInclusion(concept, concept) :: reasoner.todo)
 
-  private[this] def `R⊤left`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState =
-    if (subclass.signature(Top)) reasoner.copy(topOccursNegatively = true) else reasoner
+  private[this] def `R⊤left`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState =
+    if (ci.subclass.signature(Top)) reasoner.copy(topOccursNegatively = true) else reasoner
 
   private[this] def `R⊤right`(concept: Concept, reasoner: ReasonerState): ReasonerState =
-    if (reasoner.topOccursNegatively) processConceptInclusion(concept, Top, reasoner)
+    if (reasoner.topOccursNegatively) reasoner.copy(todo = ConceptInclusion(concept, Top) :: reasoner.todo)
     else reasoner
 
-  private[this] def `R⊑left`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState =
-    reasoner.closureSubsBySuperclass.getOrElse(subclass, Set.empty).foldLeft(reasoner) { (state, other) =>
-      processConceptInclusion(other, superclass, state)
+  private[this] def `R⊑left`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    reasoner.closureSubsBySuperclass.getOrElse(ci.subclass, Set.empty).foreach { other =>
+      todo = ConceptInclusion(other, ci.superclass) :: todo
     }
-
-  private[this] def `R⊑right`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState =
-    reasoner.assertedConceptInclusionsBySubclass.getOrElse(superclass, Nil).foldLeft(reasoner) { (state, other) =>
-      processConceptInclusion(subclass, other.superclass, state)
-    }
-
-  private[this] def `R⊥left`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState =
-    if (superclass == Bottom) {
-      reasoner.linksByTarget.getOrElse(subclass, Map.empty).foldLeft(reasoner) { case (state1, (_, subjects)) =>
-        subjects.foldLeft(state1) { (state2, subject) =>
-          processConceptInclusion(subject, Bottom, state2)
-        }
-      }
-    } else reasoner
-
-  private[this] def `R⊥right`(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState =
-    if (reasoner.closureSubsBySuperclass(Bottom)(target))
-      processConceptInclusion(subject, Bottom, reasoner)
-    else reasoner
-
-  private[this] def `R-⨅`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = superclass match {
-    case Conjunction(left, right) =>
-      processConceptInclusion(subclass, left,
-        processConceptInclusion(subclass, right, reasoner))
-    case _                        => reasoner
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R+⨅a`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
-    val newNegativeConjunctions = subclass.conceptSignature.collect { case conj: Conjunction => conj }.filterNot(reasoner.assertedNegConjs)
+  private[this] def `R⊑right`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    reasoner.assertedConceptInclusionsBySubclass.getOrElse(ci.superclass, Nil).foreach { other =>
+      todo = ConceptInclusion(ci.subclass, other.superclass) :: todo
+    }
+    reasoner.copy(todo = todo)
+  }
+
+  private[this] def `R⊥left`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    if (ci.superclass == Bottom) {
+      for {
+        (_, subjects) <- reasoner.linksByTarget.getOrElse(ci.subclass, Map.empty)
+        subject <- subjects
+      } todo = ConceptInclusion(subject, Bottom) :: todo
+      reasoner.copy(todo = todo)
+    } else reasoner
+  }
+
+  private[this] def `R⊥right`(link: Link, reasoner: ReasonerState): ReasonerState = {
+    if (reasoner.closureSubsBySuperclass(Bottom)(link.target))
+      reasoner.copy(todo = ConceptInclusion(link.subject, Bottom) :: reasoner.todo)
+    else reasoner
+  }
+
+  private[this] def `R-⨅`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = ci match {
+    case ConceptInclusion(sub, Conjunction(left, right)) => reasoner.copy(todo = ConceptInclusion(sub, left) :: ConceptInclusion(sub, right) :: reasoner.todo)
+    case _                                               => reasoner
+  }
+
+  private[this] def `R+⨅a`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    val newNegativeConjunctions = ci.subclass.conceptSignature.collect { case conj: Conjunction => conj }.filterNot(reasoner.assertedNegConjs)
     val newAssertedNegConjs = reasoner.assertedNegConjs ++ newNegativeConjunctions
     val newNegConjsByOperandRight = newNegativeConjunctions.foldLeft(reasoner.assertedNegConjsByOperandRight) {
       case (acc, c @ Conjunction(_, right)) =>
@@ -267,45 +288,49 @@ object Reasoner {
     `R+⨅left`(newSubclassesAndConjunctions, reasoner.copy(conjunctionsBySubclassesOfRightOperand = conjunctionsBySubclassesOfRightOperand))
   }
 
-  private[this] def `R+⨅b-right`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
+  private[this] def `R+⨅b-right`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
     var conjunctionsBySubclassesOfRightOperand = reasoner.conjunctionsBySubclassesOfRightOperand
     var newSubclassesAndConjunctions: List[(Concept, Conjunction)] = Nil
-    val conjunctions = reasoner.assertedNegConjsByOperandRight.getOrElse(superclass, Nil)
+    val conjunctions = reasoner.assertedNegConjsByOperandRight.getOrElse(ci.superclass, Nil)
     for {
       conjunction <- conjunctions
     } {
-      newSubclassesAndConjunctions = (subclass -> conjunction) :: newSubclassesAndConjunctions
-      val conjunctionsByLeft = conjunctionsBySubclassesOfRightOperand.getOrElse(subclass, Map.empty)
+      newSubclassesAndConjunctions = (ci.subclass -> conjunction) :: newSubclassesAndConjunctions
+      val conjunctionsByLeft = conjunctionsBySubclassesOfRightOperand.getOrElse(ci.subclass, Map.empty)
       val newConjunctionsForThisLeft = conjunctionsByLeft.getOrElse(conjunction.left, Set.empty) + conjunction
       val newValue = conjunctionsByLeft.updated(conjunction.left, newConjunctionsForThisLeft)
-      conjunctionsBySubclassesOfRightOperand = conjunctionsBySubclassesOfRightOperand.updated(subclass, newValue)
+      conjunctionsBySubclassesOfRightOperand = conjunctionsBySubclassesOfRightOperand.updated(ci.subclass, newValue)
     }
     `R+⨅left`(newSubclassesAndConjunctions, reasoner.copy(conjunctionsBySubclassesOfRightOperand = conjunctionsBySubclassesOfRightOperand))
   }
 
   private[this] def `R+⨅left`(subclassesAndConjunctions: Iterable[(Concept, Conjunction)], reasoner: ReasonerState): ReasonerState = {
-    subclassesAndConjunctions.foldLeft(reasoner) { case (state, (c, conjunction)) =>
-      val subclasses = reasoner.closureSubsBySuperclass.getOrElse(conjunction.left, Set.empty)
-      if (subclasses(c)) processSubPlus(c, conjunction, state)
-      else state
-    }
+    var todo = reasoner.todo
+    for {
+      (c, conjunction) <- subclassesAndConjunctions
+      subclasses = reasoner.closureSubsBySuperclass.getOrElse(conjunction.left, Set.empty)
+      if subclasses(c)
+    } todo = `Sub+`(ConceptInclusion(c, conjunction)) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R+⨅right`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
-    val conjunctionsByLeft = reasoner.conjunctionsBySubclassesOfRightOperand.getOrElse(subclass, Map.empty)
-    val conjunctions = conjunctionsByLeft.getOrElse(superclass, Set.empty)
-    conjunctions.foldLeft(reasoner) { (state, conjunction) =>
-      processSubPlus(subclass, conjunction, state)
-    }
+  private[this] def `R+⨅right`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    val conjunctionsByLeft = reasoner.conjunctionsBySubclassesOfRightOperand.getOrElse(ci.subclass, Map.empty)
+    val conjunctions = conjunctionsByLeft.getOrElse(ci.superclass, Set.empty)
+    for {
+      conjunction <- conjunctions
+    } todo = `Sub+`(ConceptInclusion(ci.subclass, conjunction)) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R-∃`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = superclass match {
-    case ExistentialRestriction(role, filler) => processLink(subclass, role, filler, reasoner)
-    case _                                    => reasoner
+  private[this] def `R-∃`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = ci match {
+    case ConceptInclusion(c, ExistentialRestriction(role, filler)) => reasoner.copy(todo = Link(c, role, filler) :: reasoner.todo)
+    case _                                                         => reasoner
   }
 
-  private[this] def `R+∃a`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = {
-    val newNegativeExistentials = subclass.conceptSignature.collect { case er: ExistentialRestriction => er }
+  private[this] def `R+∃a`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = {
+    val newNegativeExistentials = ci.subclass.conceptSignature.collect { case er: ExistentialRestriction => er }
     val negExistsMapByConcept = newNegativeExistentials.foldLeft(reasoner.negExistsMapByConcept) { (acc, er) =>
       val updated = acc.getOrElse(er.concept, Set.empty) + er
       acc.updated(er.concept, updated)
@@ -328,66 +353,66 @@ object Reasoner {
     `R+∃left`(newPropagations, reasoner.copy(propagations = propagations))
   }
 
-  private[this] def `R+∃b-right`(subclass: Concept, superclass: Concept, reasoner: ReasonerState): ReasonerState = { //speed up
+  private[this] def `R+∃b-right`(ci: ConceptInclusion, reasoner: ReasonerState): ReasonerState = { //speed up
     var newPropagations: List[(Concept, ExistentialRestriction)] = Nil
     var propagations = reasoner.propagations
-    val ers = reasoner.negExistsMapByConcept.getOrElse(superclass, Set.empty)
+    val ers = reasoner.negExistsMapByConcept.getOrElse(ci.superclass, Set.empty)
     for {
       er <- ers
     } {
-      newPropagations = (subclass, er) :: newPropagations
-      val current = propagations.getOrElse(subclass, Map.empty)
+      newPropagations = (ci.subclass, er) :: newPropagations
+      val current = propagations.getOrElse(ci.subclass, Map.empty)
       val newList = er :: current.getOrElse(er.role, Nil)
-      propagations = propagations.updated(subclass, current.updated(er.role, newList))
+      propagations = propagations.updated(ci.subclass, current.updated(er.role, newList))
     }
     `R+∃left`(newPropagations, reasoner.copy(propagations = propagations))
   }
 
   private[this] def `R+∃left`(newPropagations: Iterable[(Concept, ExistentialRestriction)], reasoner: ReasonerState): ReasonerState = {
-    newPropagations.foldLeft(reasoner) { case (state1, (concept, er)) =>
-      reasoner.linksByTarget.getOrElse(concept, Map.empty).foldLeft(state1) { case (state2, (role, subjects)) =>
-        if (reasoner.hier.getOrElse(role, Set.empty)(er.role))
-          subjects.foldLeft(state2) { (state3, subject) =>
-            processSubPlus(subject, er, state3)
-          }
-        else state2
-      }
-    }
+    var todo = reasoner.todo
+    for {
+      (concept, er) <- newPropagations
+      (role, subjects) <- reasoner.linksByTarget.getOrElse(concept, Map.empty)
+      // This getOrElse could be removed if new roles are added to hier anytime assertions are added
+      if reasoner.hier.getOrElse(role, Set.empty)(er.role)
+      subject <- subjects
+    } todo = `Sub+`(ConceptInclusion(subject, er)) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R+∃right`(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState = {
-    val roleToER = reasoner.propagations.getOrElse(target, Map.empty)
-    reasoner.hier.getOrElse(role, Set.empty).foldLeft(reasoner) { (state1, s) =>
-      roleToER.getOrElse(s, Nil).foldLeft(state1) { (state2, f) =>
-        processSubPlus(subject, f, state2)
-      }
-    }
+  private[this] def `R+∃right`(link: Link, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    val roleToER = reasoner.propagations.getOrElse(link.target, Map.empty)
+    for {
+      s <- reasoner.hier.getOrElse(link.role, Set.empty)
+      f <- roleToER.getOrElse(s, Nil)
+    } todo = `Sub+`(ConceptInclusion(link.subject, f)) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R∘left`(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState = {
-    reasoner.linksByTarget.getOrElse(subject, Map.empty).foldLeft(reasoner) { case (state1, (r1, es)) =>
-      val r1s = reasoner.hierComps.getOrElse(r1, Map.empty)
-      r1s.getOrElse(role, Nil).foldLeft(state1) { (state2, s) =>
-        es.foldLeft(state2) { (state3, e) =>
-          processLink(e, s, target, state3)
-        }
-      }
-    }
+  private[this] def `R∘left`(link: Link, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    for {
+      (r1, es) <- reasoner.linksByTarget.getOrElse(link.subject, Map.empty)
+      r1s = reasoner.hierComps.getOrElse(r1, Map.empty)
+      s <- r1s.getOrElse(link.role, Nil)
+      e <- es
+    } todo = Link(e, s, link.target) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R∘right`(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState = {
-    val r2s = reasoner.hierComps.getOrElse(role, Map.empty)
-    reasoner.linksBySubject.getOrElse(target, Map.empty).foldLeft(reasoner) { case (state1, (r2, targets)) =>
-      r2s.getOrElse(r2, Nil).foldLeft(state1) { (state2, s) =>
-        targets.foldLeft(state2) { (state3, d) =>
-          processLink(subject, s, d, state3)
-        }
-      }
-    }
+  private[this] def `R∘right`(link: Link, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    val r2s = reasoner.hierComps.getOrElse(link.role, Map.empty)
+    for {
+      (r2, targets) <- reasoner.linksBySubject.getOrElse(link.target, Map.empty)
+      s <- r2s.getOrElse(r2, Nil)
+      d <- targets
+    } todo = Link(link.subject, s, d) :: todo
+    reasoner.copy(todo = todo)
   }
 
-  private[this] def `R⤳`(subject: Concept, role: Role, target: Concept, reasoner: ReasonerState): ReasonerState =
-    processConcept(target, reasoner)
+  private[this] def `R⤳`(link: Link, reasoner: ReasonerState): ReasonerState = reasoner.copy(todo = link.target :: reasoner.todo)
 
   private[this] def `R⊔`(d: Disjunction): Set[ConceptInclusion] = d.operands.map(o => ConceptInclusion(o, d))
 

--- a/src/main/scala/org/geneontology/whelk/ReteNodes.scala
+++ b/src/main/scala/org/geneontology/whelk/ReteNodes.scala
@@ -121,8 +121,8 @@ final case class ConceptAtomJoinNode(atom: ConceptAtom, children: List[BetaNode]
       case variable: Variable if parentBoundVariables(variable) =>
         val ind = token.bindings(variable)
         if (alphaMem.individuals(ind)) List(token) else Nil
-      case variable: Variable                                   => alphaMem.individuals.toList.map(i => token.extend(Map(variable -> i)))
-      case individualArg: Individual                            => if (alphaMem.individuals(individualArg)) List(token) else Nil
+      case variable: Variable        => alphaMem.individuals.toList.map(i => token.extend(Map(variable -> i)))
+      case individualArg: Individual => if (alphaMem.individuals(individualArg)) List(token) else Nil
     }
     activateChildren(newTokens, reasoner)
   }
@@ -130,12 +130,12 @@ final case class ConceptAtomJoinNode(atom: ConceptAtom, children: List[BetaNode]
   def rightActivate(individual: Individual, reasoner: ReasonerState): ReasonerState = {
     val parentMem = reasoner.wm.beta(leftParentSpec)
     val newTokens = atom.argument match {
-      case variable: Variable                                       => parentMem.tokenIndex.get(variable) match {
+      case variable: Variable => parentMem.tokenIndex.get(variable) match {
         case Some(bound) => bound.getOrElse(individual, Nil).toList
         case None        => parentMem.tokens.map(_.extend(Map(variable -> individual)))
       }
       case individualArg: Individual if individualArg != individual => Nil
-      case _: Individual                                            => parentMem.tokens
+      case _: Individual                                  => parentMem.tokens
     }
     activateChildren(newTokens, reasoner)
   }
@@ -148,9 +148,9 @@ final case class RoleAtomJoinNode(atom: RoleAtom, children: List[BetaNode], spec
 
   private val makeBindings: RoleAssertion => Map[Variable, Individual] = atom match {
     case RoleAtom(_, subjectVar: Variable, targetVar: Variable) => (ra: RoleAssertion) => Map(subjectVar -> ra.subject, targetVar -> ra.target)
-    case RoleAtom(_, _, targetVar: Variable)                    => (ra: RoleAssertion) => Map(targetVar -> ra.target)
-    case RoleAtom(_, subjectVar: Variable, _)                   => (ra: RoleAssertion) => Map(subjectVar -> ra.subject)
-    case _                                                      => (_: RoleAssertion) => Map.empty
+    case RoleAtom(_, _, targetVar: Variable) => (ra: RoleAssertion) => Map(targetVar -> ra.target)
+    case RoleAtom(_, subjectVar: Variable, _) => (ra: RoleAssertion) => Map(subjectVar -> ra.subject)
+    case _ => (_: RoleAssertion) => Map.empty
   }
 
   val findTokensForAssertion: (RoleAssertion, BetaMemory) => List[Token] = (atom.subject, atom.target) match {
@@ -162,7 +162,7 @@ final case class RoleAtomJoinNode(atom: RoleAtom, children: List[BetaNode], spec
           subjectTokens.intersect(parentMem.tokenIndex(targetVariable).getOrElse(assertion.target, Set.empty)).toList
         else Nil
       }
-    case (subjectVariable: Variable, _: Variable) if parentBoundVariables(subjectVariable)                                                      =>
+    case (subjectVariable: Variable, _: Variable) if parentBoundVariables(subjectVariable) =>
       (assertion: RoleAssertion, parentMem: BetaMemory) => parentMem.tokenIndex(subjectVariable).getOrElse(assertion.subject, Set.empty).toList.map(t => t.extend(makeBindings(assertion)))
 
     case (_: Variable, targetVariable: Variable) if parentBoundVariables(targetVariable) =>
@@ -174,13 +174,13 @@ final case class RoleAtomJoinNode(atom: RoleAtom, children: List[BetaNode], spec
           parentMem.tokenIndex(subjectVariable).getOrElse(assertion.subject, Set.empty).toList.map(t => t.extend(makeBindings(assertion)))
         else Nil
       }
-    case (individualArg: Individual, targetVariable: Variable) if parentBoundVariables(targetVariable)   =>
+    case (individualArg: Individual, targetVariable: Variable) if parentBoundVariables(targetVariable) =>
       (assertion: RoleAssertion, parentMem: BetaMemory) => {
         if (individualArg == assertion.subject)
           parentMem.tokenIndex(targetVariable).getOrElse(assertion.target, Set.empty).toList.map(t => t.extend(makeBindings(assertion)))
         else Nil
       }
-    case (individualSubject: Individual, individualTarget: Individual)                                   =>
+    case (individualSubject: Individual, individualTarget: Individual) =>
       (assertion: RoleAssertion, parentMem: BetaMemory) => {
         if ((individualSubject == assertion.subject) && (individualTarget == assertion.target)) parentMem.tokens
         else Nil
@@ -200,7 +200,7 @@ final case class RoleAtomJoinNode(atom: RoleAtom, children: List[BetaNode], spec
             subjectAssertions.intersect(alphaMem.assertionsByTarget.getOrElse(token.bindings(targetVariable), Nil))
           else Nil
         }
-      case (subjectVariable: Variable, _: Variable) if parentBoundVariables(subjectVariable)                                                      =>
+      case (subjectVariable: Variable, _: Variable) if parentBoundVariables(subjectVariable) =>
         (token: Token, alphaMem: RoleAlphaMemory) =>
           alphaMem.assertionsBySubject.getOrElse(token.bindings(subjectVariable), Nil)
 
@@ -263,13 +263,18 @@ final case class RoleAtomJoinNode(atom: RoleAtom, children: List[BetaNode], spec
 
 final case class ProductionNode(rule: Rule) extends BetaNode {
 
-  def leftActivate(token: Token, reasoner: ReasonerState): ReasonerState =
-    rule.head.foldLeft(reasoner) { (state, atom) =>
+  def leftActivate(token: Token, reasoner: ReasonerState): ReasonerState = {
+    var todo = reasoner.todo
+    for {
+      atom <- rule.head
+    } {
       atom match {
-        case RoleAtom(role, subj, obj) => Reasoner.processLink(Nominal(fillVariable(subj, token)), role, Nominal(fillVariable(obj, token)), state)
-        case ConceptAtom(concept, arg) => Reasoner.processConceptInclusion(Nominal(fillVariable(arg, token)), concept, state)
+        case RoleAtom(role, subj, obj) => todo = Link(Nominal(fillVariable(subj, token)), role, Nominal(fillVariable(obj, token))) :: todo
+        case ConceptAtom(concept, arg) => todo = ConceptInclusion(Nominal(fillVariable(arg, token)), concept) :: todo
       }
     }
+    reasoner.copy(todo = todo)
+  }
 
   private def fillVariable(arg: IndividualArgument, token: Token): Individual = arg match {
     case v: Variable   => token.bindings(v)


### PR DESCRIPTION
Some very large complicated ontologies cause a stack overflow if a queue is not used.

This reverts commit 527a39406b19534d2d50f9282f68515bb80de918.