### PR TITLE
Add queue delegates capability.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization  := "org.geneontology"
 
 name          := "whelk"
 
-version       := "0.4"
+version       := "0.5"
 
 publishMavenStyle := true
 


### PR DESCRIPTION
This allows outside code to inject functionality into the queue processing done by the reasoner. This allows various non-standard reasoning, logging, or arbitrary checks to be done.